### PR TITLE
feat(02-mcp-rag): 添加 DeepSeek API 集成的 RAG 客户端，用 阿里云百炼替换 OpenAI 的 api …

### DIFF
--- a/02-mcp-rag/rag-client/client-v3-deepseek-ali.py
+++ b/02-mcp-rag/rag-client/client-v3-deepseek-ali.py
@@ -1,0 +1,106 @@
+# cd 02-mcp-rag/rag-client
+# source .venv/bin/activate
+# uv run client.py ../rag-server/server.py
+import sys, asyncio, os
+from mcp import ClientSession
+from mcp.client.stdio import stdio_client, StdioServerParameters
+from openai import OpenAI
+from dotenv import load_dotenv
+
+load_dotenv()
+
+class RagClient:
+    def __init__(self):
+        self.session = None
+        self.transport = None   # 用来保存 stdio_client 的上下文管理器
+        self.client = OpenAI(
+            api_key=os.getenv("DEEPSEEK_API_KEY"),
+            base_url="https://api.deepseek.com"
+        )
+
+    async def connect(self, server_script: str):
+        # 1) 构造参数对象
+        params = StdioServerParameters(
+            # 替换下你自己 server 下的 python 路径
+            command="/Users/wukong/00.Study/04-geektime/02.code/mcp-in-action-master/02-mcp-rag/rag-server/.venv/bin/python",
+            args=[server_script],
+        )
+        # 2) 保存上下文管理器
+        self.transport = stdio_client(params)
+        # 3) 进入上下文，拿到 stdio, write
+        self.stdio, self.write = await self.transport.__aenter__()
+
+        # 4) 初始化 MCP 会话
+        self.session = await ClientSession(self.stdio, self.write).__aenter__()
+        await self.session.initialize() # 必须要有，否则无法初始化对话
+        resp = await self.session.list_tools()
+        print("可用工具：", [t.name for t in resp.tools])
+
+    async def query(self, q: str):
+        # 1. 先检索相关文档
+        result = await self.session.call_tool(
+            "retrieve_docs",
+            {"query": q, "top_k": 3}
+        )
+        
+        # 2. 使用 DeepSeek 模型生成回答
+        response = self.client.chat.completions.create(
+            model="deepseek-chat",
+            messages=[
+                {"role": "system", "content": "你是一个专业的医学助手，请根据提供的医学文档回答问题。"},
+                {"role": "user", "content": f"问题：{q}\n\n相关文档：\n{result}\n\n请根据以上文档回答我的问题。"}
+            ],
+            stream=False
+        )
+        
+        print("检索结果：\n", result)
+        print("\nAI 回答：\n", response.choices[0].message.content)
+
+    async def close(self):
+        # 先关闭 MCP 会话
+        await self.session.__aexit__(None, None, None)
+        # 再退出 stdio_client 上下文
+        await self.transport.__aexit__(None, None, None)
+
+async def main():
+    print(">>> 开始初始化 RAG 系统")
+    if len(sys.argv) < 2:
+        print("用法: python client.py <server.py 路径>")
+        return
+
+    client = RagClient()
+    await client.connect(sys.argv[1])
+    print(">>> 系统连接成功")
+
+    # 添加一些医学文档
+    medical_docs = [
+        "糖尿病是一种慢性代谢性疾病，主要特征是血糖水平持续升高。",
+        "高血压是指动脉血压持续升高，通常定义为收缩压≥140mmHg和/或舒张压≥90mmHg。",
+        "冠心病是由于冠状动脉粥样硬化导致心肌缺血缺氧的疾病。",
+        "哮喘是一种慢性气道炎症性疾病，表现为反复发作的喘息、气促、胸闷和咳嗽。",
+        "肺炎是由细菌、病毒或其他病原体引起的肺部感染，常见症状包括发热、咳嗽和呼吸困难。",
+        "感冒是一种非常奇怪的疾病，主要特征是血糖水平持续降低。"
+    ]
+
+    print(">>> 正在索引医学文档...")
+    res = await client.session.call_tool(
+        "index_docs",
+        {"docs": medical_docs}
+    )
+    print(">>> 文档索引完成")
+
+    while True:
+        print("\n请输入您要查询的医学问题（输入'退出'结束查询）：")
+        query = input("> ")
+        
+        if query.lower() == '退出':
+            break
+            
+        print(f"\n正在查询: {query}")
+        await client.query(query)
+
+    await client.close()
+    print(">>> 系统已关闭")
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
feat(02-mcp-rag): 添加 DeepSeek API 集成的 RAG 客户端，用 阿里云百炼替换 OpenAI 的 api key。添加了一个错误的对感冒描述的文档。

遇到的问题和经验总结：
1、示例中的 openai 不是一般人能用的，首先得学术上网，然后还得申请一个 openai 的 api key，还需要充值。
2、.env 文件需要自己创建一个，Google 的那个 api key 不需要。如果你访问不了 openai，就用阿里云百炼。官网：https://bailian.console.aliyun.com/?tab=model#/api-key
3、示例代码的文件名和目录名和文章中的不一样，需要自己调整下，比如 client 和 server 目录，特别注意 client 中的有个 mcp server 的路径，对应的 command 变量，它是一个绝对路径，我用的 MacOS，路径前面一段必须是 “/Users/wukong/”，不能是“～”，否则会报找不到路径。
4、我用的 deepseek 作为推理大模型， 直接用这个命令跑就行，uv run client-v3-deepseek-ali.py ../rag-server/server.py
5、索引的文档只有几种病症，都放在 medical_docs 变量里面在，如果你输入一个 感冒，会提示检索不到。不要以为是程序问题，自己再一个文档丢进去就行。
6、另外我做了一个好玩的事情，我加了一个感冒的文档，但是对感冒的描述是错的，最后的现象是 能检索到这个文档，但是将问题+检索到的内容丢给大模型时，大模型会告诉我文档有明显的问题。AI 回答：“根据提供的文档内容，关于感冒的描述存在明显错误或不准确的信息。文档中提到的感冒特征为"血糖水平持续降低"[5]，这与医学上对感冒（上呼吸道病毒感染）的认知完全不符。” 如下图所示：
<img width="1166" alt="image" src="https://github.com/user-attachments/assets/5e27513a-5080-460e-9c8f-7b55c19b998a" />

7、将 openai 替换为 阿里云百炼的代码如下。官网文档有示例代码，需要注意的是维度需要改成一样的，1536。

``` python
client = OpenAI(
    api_key=os.getenv("DASHSCOPE_API_KEY"),  # 如果您没有配置环境变量，请在此处用您的API Key进行替换
    base_url="https://dashscope.aliyuncs.com/compatible-mode/v1"  # 百炼服务的base_url
)

async def embed_text(texts: List[str]) -> np.ndarray:
    resp = client.embeddings.create(
        model="text-embedding-v4",
        input=texts,
        dimensions=1536,# 指定向量维度（仅 text-embedding-v3及 text-embedding-v4支持该参数）
        encoding_format="float"
    )
    return np.array([d.embedding for d in resp.data], dtype='float32')
```
