### PR TITLE
refactor(02-mcp-rag): 优化RAG客户端Python路径获取方式。使用os获取当前文件绝对路径后，结合相对路径动态获取…

### DIFF
--- a/02-mcp-rag/rag-client/client-v3-deepseek-ali.py
+++ b/02-mcp-rag/rag-client/client-v3-deepseek-ali.py
@@ -20,9 +20,10 @@ class RagClient:
 
     async def connect(self, server_script: str):
         # 1) 构造参数对象
+        current_folder = os.path.dirname(os.path.abspath(__file__))
+        command = os.path.join(current_folder, "../rag-server/.venv/bin/python")
         params = StdioServerParameters(
-            # 替换下你自己 server 下的 python 路径
-            command="/Users/wukong/00.Study/04-geektime/02.code/fork/mcp-in-action/02-mcp-rag/rag-server/.venv/bin/python",
+            command=command,
             args=[server_script],
         )
         # 2) 保存上下文管理器


### PR DESCRIPTION
启动client端时，如果代码中硬编码的路径没有替换，运行`uv run client-v3-deepseek-ali.py ../rag-server/server-ali.py`会出现路径错误。
于是替换原本代码中`command="/Users/wukong/00.Study/04-geektime/02.code/fork/mcp-in-action/02-mcp-rag/rag-server/.venv/bin/python"`的硬编码方式，改为通过os库来获取当前文件所在目录绝对路径后，通过`command = os.path.join(current_folder, "../rag-server/.venv/bin/python")`的方式动态生成指令路径，省去手工替换路径的麻烦